### PR TITLE
Update @websdk/nap and @websdk/rhumb dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zambezi/address",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "API for nap resources",
   "main": "lib/address.js",
   "devDependencies": {


### PR DESCRIPTION
Update to the latest nap and rhumb versions:

- @websdk/nap v0.11.2
- @websdk/rhumb v0.3.9