### PR TITLE
Add detach function for cleaning up child views

### DIFF
--- a/test/view-wrapper.test.js
+++ b/test/view-wrapper.test.js
@@ -63,6 +63,19 @@ define(function(require) {
       callback.should.have.been.calledOnce
     })
 
+    it('should dispatch "resourcewillchange" when calling detach with the DOMElement', function() {
+
+      eventName = 'resourcewillchange'
+      node.addEventListener(eventName, callback)
+
+      wrapView(location, reqOne, resOne)
+      resOne.body(node)
+      callback.reset()
+      resOne.body.detach(node)
+
+      callback.should.have.been.calledOnce
+    })
+
     it('should dispatch "resourcewillchange" when addressing a different resource on the same DOMElement', function () {
 
       eventName = 'resourcewillchange'

--- a/view-wrapper.js
+++ b/view-wrapper.js
@@ -15,9 +15,15 @@ define(function(require) {
 
       if(zapp.isRoot(node)) location.replaceState(uri)
       if(resourceWillChange(req, res, node)) dispatchEvent(node, 'resourcewillchange')
-      dispatchEvent(node, 'update', {detail : { from : zapp.resource(node), to : uri }})
+      dispatchEvent(node, 'update', { detail: { from: zapp.resource(node), to: uri } })
       zapp.resource(node, uri)
       view(node)
+    }
+
+    res.body.detach = function (node) {
+      dispatchEvent(node, 'resourcewillchange')
+      dispatchEvent(node, 'update', { detail: { from: zapp.resource(node), to: null } })
+      zapp.resource(node, undefined)
     }
   }
 


### PR DESCRIPTION
Motivation:

When we request in a view for a child resource, by default it will only be notified when any view function is called on the same the DOM node. This is useful as it enables the child view to knows when it is created, updated or replaced. This can present some problems when a view has been removed from the page, as the child resource can't close any of its open resources or clean up any orphaned DOM elements it is keeping hold of.

---

I am not sure if detach is the name we want to go for, so let us discuss this further on this PR.

----

See GH-49 for initial discussion.